### PR TITLE
Update git-intent to v0.0.6

### DIFF
--- a/Formula/git-intent.rb
+++ b/Formula/git-intent.rb
@@ -2,11 +2,11 @@ class GitIntent < Formula
   desc "Git workflow tool for intentional commits"
   homepage "https://github.com/offlegacy/git-intent"
   license "MIT"
-  version "0.0.3"
+  version "0.0.6"
 
   on_macos do
     url "https://github.com/offlegacy/git-intent/releases/download/v#{version}/git-intent-#{version}-darwin-amd64.tar.gz"
-    sha256 "9d180199c83702c90a8b25ac64c30a8893e60859ee2ff7f86f0ed98126e4fde5"
+    sha256 "8e3e98da9b0688707e9190eb2e00140d0d1c4547660b52b995783206c13e5677"
   end
 
   def install


### PR DESCRIPTION
Updates git-intent to v0.0.6

- Version: 0.0.6
- SHA256: 8e3e98da9b0688707e9190eb2e00140d0d1c4547660b52b995783206c13e5677