### PR TITLE
Update git-intent to v0.0.8

### DIFF
--- a/Formula/git-intent.rb
+++ b/Formula/git-intent.rb
@@ -2,11 +2,11 @@ class GitIntent < Formula
   desc "Git workflow tool for intentional commits"
   homepage "https://github.com/offlegacy/git-intent"
   license "MIT"
-  version "0.0.7"
+  version "0.0.8"
 
   on_macos do
     url "https://github.com/offlegacy/git-intent/releases/download/v#{version}/git-intent-#{version}-darwin-amd64.tar.gz"
-    sha256 "39f4198d060df77b40bd4af3645ababed7ac08c8ed3da48e07638c4f018b3079"
+    sha256 "5f808db0760918575bcdc440398b66de875cab19e83de03003fc1d12c2e52920"
   end
 
   def install


### PR DESCRIPTION
Updates git-intent to v0.0.8

- Version: 0.0.8
- SHA256: 5f808db0760918575bcdc440398b66de875cab19e83de03003fc1d12c2e52920