### PR TITLE
Update git-intent to v0.0.9

### DIFF
--- a/Formula/git-intent.rb
+++ b/Formula/git-intent.rb
@@ -2,11 +2,11 @@ class GitIntent < Formula
   desc "Git workflow tool for intentional commits"
   homepage "https://github.com/offlegacy/git-intent"
   license "MIT"
-  version "0.0.8"
+  version "0.0.9"
 
   on_macos do
     url "https://github.com/offlegacy/git-intent/releases/download/v#{version}/git-intent-#{version}-darwin-amd64.tar.gz"
-    sha256 "5f808db0760918575bcdc440398b66de875cab19e83de03003fc1d12c2e52920"
+    sha256 "8d0b3eeae5d6c68316cdf0c28574b2d8d346cf70cd43567d42bd16b7fe839c04"
   end
 
   def install


### PR DESCRIPTION
Updates git-intent to v0.0.9

- Version: 0.0.9
- SHA256: 8d0b3eeae5d6c68316cdf0c28574b2d8d346cf70cd43567d42bd16b7fe839c04